### PR TITLE
Tach test suite

### DIFF
--- a/tach/config.py
+++ b/tach/config.py
@@ -98,7 +98,7 @@ class Notifier(object):
         self.additional = {}
 
         self.label = label.partition(':')[-1]
-        if not label:
+        if not self.label:
             # No label makes this the default
             self.default = True
 

--- a/tach/config.py
+++ b/tach/config.py
@@ -297,6 +297,10 @@ class Method(object):
     def app(self):
         """Return the application transformer."""
 
+        # Don't crash if we don't have an app set
+        if not self._app or not self._app_path:
+            return None
+
         if not self._app_cache:
             app_cls = utils.import_class_or_module(self._app_path)
             self._app_cache = getattr(app_cls, self._app)

--- a/tach/config.py
+++ b/tach/config.py
@@ -34,7 +34,8 @@ class Config(object):
                 self.notifiers.setdefault(notifier.label, notifier)
 
                 # If it's a default notifier, add it as such
-                self.notifiers.setdefault(None, notifier)
+                if notifier.default:
+                    self.notifiers.setdefault(None, notifier)
             else:
                 # Make a method
                 method = Method(self, sec, config.items(sec))
@@ -43,7 +44,7 @@ class Config(object):
                 self.methods.setdefault(method.label, method)
 
         # Do we have a default notifier?
-        self.notifiers.setdefault(None, Notifier(self, '', []))
+        self.notifiers.setdefault(None, Notifier(self, 'notifier', []))
 
     def notifier(self, name):
         """Retrieve a notifier driver given its name."""

--- a/tach/config.py
+++ b/tach/config.py
@@ -26,8 +26,7 @@ class Config(object):
 
         # Process configuration
         for sec in config.sections():
-            if (sec in ('graphite.config', 'statsd.config') or
-                sec == 'notifier' or sec.startswith('notifier:')):
+            if sec == 'notifier' or sec.startswith('notifier:'):
                 # Make a notifier
                 notifier = Notifier(self, sec, config.items(sec))
 
@@ -98,27 +97,10 @@ class Notifier(object):
         self._driver_cache = None
         self.additional = {}
 
-        # Parse the label for backwards compatibility
-        if label == 'graphite.config':
-            # Graphite driver
+        self.label = label.partition(':')[-1]
+        if not label:
+            # No label makes this the default
             self.default = True
-            self.label = 'graphite'
-            self._driver = notifiers.GraphiteNotifier
-            self._driver_cache = self._driver(self,
-                                              'carbon_host', 'carbon_port')
-        elif label == 'statsd.config':
-            # StatsD driver
-            self.default = True
-            self.label = 'statsd'
-            self._driver = notifiers.StatsDNotifier
-            self._driver_cache = self._driver(self,
-                                              'statsd_host', 'statsd_port')
-        else:
-            # New-style configuration
-            self.label = label.partition(':')[-1]
-            if not label:
-                # No label makes this the default
-                self.default = True
 
         # Process configuration
         for option, value in items:

--- a/tach/config.py
+++ b/tach/config.py
@@ -245,6 +245,10 @@ class Method(object):
         # Wrap the method to perform statistics collection
         @functools.wraps(method)
         def wrapper(*args, **kwargs):
+            # Deal with class method calling conventions
+            if kind == 'class method':
+                args = args[1:]
+
             # Handle app translation
             label = None
             if self._app:

--- a/tach/config.py
+++ b/tach/config.py
@@ -247,7 +247,7 @@ class Method(object):
         def wrapper(*args, **kwargs):
             # Handle app translation
             label = None
-            if self.app:
+            if self._app:
                 args, kwargs, label = self.app(*args, **kwargs)
 
             # Run the method, bracketing with statistics collection

--- a/tach/config.py
+++ b/tach/config.py
@@ -195,14 +195,12 @@ class Method(object):
 
         self.config = config
         self.label = label
-        self._method_cache = None
         self._app_cache = None
         self._metric_cache = None
 
         # Other important configuration values
-        attrs = set(['module', 'method', 'metric', 'notifier',
-                     'app', 'app_path'])
         required = set(['module', 'method', 'metric'])
+        attrs = set(['notifier', 'app', 'app_path']) | required
         for attr in attrs:
             setattr(self, '_' + attr, None)
         self.additional = {}
@@ -224,7 +222,7 @@ class Method(object):
         # Make sure we got the essential configuration
         if required:
             raise Exception("Missing configuration options for %s: %s" %
-                            (sec, ', '.join(required)))
+                            (label, ', '.join(required)))
 
         # Grab the method we're operating on
         method_cls = utils.import_class_or_module(self._module)

--- a/tach/config.py
+++ b/tach/config.py
@@ -105,9 +105,7 @@ class Notifier(object):
         # Process configuration
         for option, value in items:
             if option == 'driver':
-                # Get the driver, but only if we don't have one
-                if not self._driver:
-                    self._driver = utils.import_class_or_module(value)
+                self._driver = utils.import_class_or_module(value)
 
             # Other options go into additional
             else:

--- a/tach/notifiers.py
+++ b/tach/notifiers.py
@@ -106,18 +106,12 @@ class DebugNotifier(BaseNotifier):
 class SocketNotifier(BaseNotifier):
     """Base class for notifiers using sockets."""
 
-    def __init__(self, config, hostattr='host', portattr='port'):
-        """Initialize a SocketNotifier.
-
-        The legacy configuration for the Graphite and StatsD notifiers
-        requires alternate configuration keys than the defaults.  The
-        defaults can be overridden by specifying hostattr and
-        portattr.
-        """
+    def __init__(self, config):
+        """Initialize a SocketNotifier."""
 
         super(SocketNotifier, self).__init__(config)
-        self.host = config[hostattr]
-        self.port = int(config[portattr])
+        self.host = config['host']
+        self.port = int(config['port'])
 
         # Save the socket
         self._sock = None

--- a/tach/notifiers.py
+++ b/tach/notifiers.py
@@ -100,7 +100,7 @@ class DebugNotifier(BaseNotifier):
         LOG.debug("DebugNotifier: Raw value of type %r: %r" % (vtype, value))
         LOG.debug("DebugNotifier: Statistic label: %r" % label)
 
-        return self.driver.send(body)
+        self.driver.send(body)
 
 
 class SocketNotifier(BaseNotifier):
@@ -139,7 +139,9 @@ class SocketNotifier(BaseNotifier):
                 sock.sendall(body)
             except socket.error as e:
                 if rnd:
-                    print "Error writing to server: %s" % e
+                    LOG.error("%s: Error writing to server (%s, %s): %s" %
+                              (self.__class__.__name__, self.host, self.port,
+                               e))
 
                 # Try reopening the socket next time
                 del self.sock

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,34 @@
+import logging
+import unittest
+
+import stubout
+
+from tach import utils
+
+
+class TestCase(unittest.TestCase):
+    imports = {}
+
+    def setUp(self):
+        self.stubs = stubout.StubOutForTesting()
+
+        def fake_import(module):
+            return self.imports[module]
+
+        self.stubs.Set(utils, 'import_class_or_module', fake_import)
+
+    def tearDown(self):
+        self.stubs.UnsetAll()
+
+
+class LoggingTestCase(TestCase):
+    def setUp(self):
+        super(LoggingTestCase, self).setUp()
+
+        self.logmsg = []
+
+        def log_message(logger, message):
+            self.logmsg.append(message)
+
+        self.stubs.Set(logging.Logger, 'debug', log_message)
+        self.stubs.Set(logging.Logger, 'error', log_message)

--- a/tests/fake_module.py
+++ b/tests/fake_module.py
@@ -1,0 +1,2 @@
+def function():
+    pass

--- a/tests/fake_module.py
+++ b/tests/fake_module.py
@@ -1,2 +1,2 @@
-def function():
-    pass
+def function(*args, **kwargs):
+    return dict(args=args, kwargs=kwargs)

--- a/tests/fake_module.py
+++ b/tests/fake_module.py
@@ -1,2 +1,2 @@
 def function(*args, **kwargs):
-    return dict(args=args, kwargs=kwargs)
+    return 'function', dict(args=args, kwargs=kwargs)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -267,17 +267,6 @@ class TestMethod(tests.TestCase):
         self.assertEqual(method._method_orig,
                          FakeClass.__dict__['static_method'])
 
-    def test_init_static(self):
-        method = config.Method(None, 'label', [
-                ('module', 'FakeClass'),
-                ('method', 'static_method'),
-                ('metric', 'FakeMetric')])
-
-        self.assertEqual(method._method_cls, FakeClass)
-        self.assertIsInstance(method._method_wrapper, staticmethod)
-        self.assertEqual(method._method_orig,
-                         FakeClass.__dict__['static_method'])
-
     def test_init_function(self):
         method = config.Method(None, 'label', [
                 ('module', 'fake_module'),
@@ -332,3 +321,5 @@ class TestMethod(tests.TestCase):
                 kwargs=dict(a=1, b=2, c=3)))
         self.assertEqual(method.notifier.sent_msgs,
                          ["default/'started/ended'/'fake_label'"])
+
+    def test_

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,282 @@
+import ConfigParser
+import inspect
+import StringIO
+
+from tach import config
+from tach import metrics
+from tach import notifiers
+
+import tests
+from tests import fake_module
+
+
+class FakeConfig(object):
+    def notifier(self, name):
+        return FakeNotifier(None)
+
+
+class FakeNotifier(notifiers.BaseNotifier):
+    def __init__(self, config):
+        super(FakeNotifier, self).__init__(config)
+
+        self.sent_msgs = []
+
+    def default(self, value, label):
+        return 'default/%r/%r' % (value, label)
+
+    def send(self, body):
+        self.sent_msgs.append(body)
+
+
+class FakeMetric(metrics.Metric):
+    vtype = 'fake'
+
+    def __init__(self, config):
+        super(FakeMetric, self).__init__(config)
+
+        self.config = config
+
+    def start(self):
+        return "started"
+
+    def __call__(self, value):
+        return "%s/ended" % value
+
+
+class FakeClass(object):
+    def instance_method(self):
+        pass
+
+    @classmethod
+    def class_method(cls):
+        pass
+
+    @staticmethod
+    def static_method():
+        pass
+
+
+class FakeHelper(object):
+    @staticmethod
+    def fake_helper(*args, **kwargs):
+        return args, kwargs, 'fake_label'
+
+
+class ConfigTestCase(tests.TestCase):
+    config = {}
+    notifier_class = None
+    method_class = None
+
+    def setUp(self):
+        super(ConfigTestCase, self).setUp()
+
+        def fake_read(cp, filenames):
+            if isinstance(filenames, basestring):
+                filenames = [filenames]
+            read_ok = []
+            for filename in filenames:
+                if filename not in self.config:
+                    continue
+                fp = StringIO.StringIO(self.config[filename])
+                cp._read(fp, filename)
+                fp.close()
+                read_ok.append(filename)
+            return read_ok
+
+        self.stubs.Set(ConfigParser.SafeConfigParser, 'read', fake_read)
+
+        if self.notifier_class:
+            self.stubs.Set(config, 'Notifier', self.notifier_class)
+        if self.method_class:
+            self.stubs.Set(config, 'Method', self.method_class)
+
+
+class TestNotifier(tests.TestCase):
+    imports = {'FakeNotifier': FakeNotifier}
+
+    def test_basic(self):
+        notifier = config.Notifier('config', 'notifier:basic', [
+                ('driver', 'FakeNotifier'),
+                ('foo', 'bar')])
+
+        self.assertEqual(notifier.config, 'config')
+        self.assertEqual(notifier.default, False)
+        self.assertEqual(notifier._driver, FakeNotifier)
+        self.assertEqual(notifier._driver_cache, None)
+        self.assertEqual(notifier.additional, {'foo': 'bar'})
+        self.assertEqual(notifier.label, 'basic')
+
+    def test_empty_label(self):
+        notifier = config.Notifier('config', 'notifier:', [
+                ('driver', 'FakeNotifier'),
+                ('foo', 'bar')])
+
+        self.assertEqual(notifier.config, 'config')
+        self.assertEqual(notifier.default, True)
+        self.assertEqual(notifier._driver, FakeNotifier)
+        self.assertEqual(notifier._driver_cache, None)
+        self.assertEqual(notifier.additional, {'foo': 'bar'})
+        self.assertEqual(notifier.label, '')
+
+    def test_missing_label(self):
+        notifier = config.Notifier('config', 'notifier', [
+                ('driver', 'FakeNotifier'),
+                ('foo', 'bar')])
+
+        self.assertEqual(notifier.config, 'config')
+        self.assertEqual(notifier.default, True)
+        self.assertEqual(notifier._driver, FakeNotifier)
+        self.assertEqual(notifier._driver_cache, None)
+        self.assertEqual(notifier.additional, {'foo': 'bar'})
+        self.assertEqual(notifier.label, '')
+
+    def test_missing_driver(self):
+        notifier = config.Notifier('config', 'notifier', [
+                ('foo', 'bar')])
+
+        self.assertEqual(notifier.config, 'config')
+        self.assertEqual(notifier.default, True)
+        self.assertEqual(notifier._driver, notifiers.PrintNotifier)
+        self.assertEqual(notifier._driver_cache, None)
+        self.assertEqual(notifier.additional, {'foo': 'bar'})
+        self.assertEqual(notifier.label, '')
+
+    def test_additional_config(self):
+        notifier = config.Notifier(None, 'notifier', [
+                ('foo', 'bar')])
+
+        self.assertEqual(notifier['foo'], 'bar')
+        with self.assertRaises(KeyError):
+            _foo = notifier['bar']
+
+    def test_get_driver(self):
+        notifier = config.Notifier(None, 'notifier', [
+                ('driver', 'FakeNotifier')])
+
+        self.assertIsInstance(notifier.driver, FakeNotifier)
+        self.assertEqual(notifier.driver.config, notifier)
+
+
+class TestGetMethod(tests.TestCase):
+    def test_instance_method(self):
+        obj, raw_obj, kind = config._get_method(FakeClass, 'instance_method')
+
+        self.assertEqual(obj, FakeClass.instance_method)
+        self.assertEqual(raw_obj, FakeClass.__dict__['instance_method'])
+        self.assertEqual(kind, 'method')
+
+    def test_class_method(self):
+        obj, raw_obj, kind = config._get_method(FakeClass, 'class_method')
+
+        self.assertEqual(obj, FakeClass.class_method)
+        self.assertEqual(raw_obj, FakeClass.__dict__['class_method'])
+        self.assertEqual(kind, 'class method')
+
+    def test_static_method(self):
+        obj, raw_obj, kind = config._get_method(FakeClass, 'static_method')
+
+        self.assertEqual(obj, FakeClass.static_method)
+        self.assertEqual(raw_obj, FakeClass.__dict__['static_method'])
+        self.assertEqual(kind, 'static method')
+
+
+class TestMethod(tests.TestCase):
+    imports = {
+        'FakeMetric': FakeMetric,
+        'FakeHelper': FakeHelper,
+        'FakeClass': FakeClass,
+        'fake_module': fake_module,
+        }
+
+    def test_missing_module(self):
+        regexp = 'Missing configuration options for label: module'
+        with self.assertRaisesRegexp(Exception, regexp):
+            method = config.Method(None, 'label', [
+                    ('method', 'instance_method'),
+                    ('metric', 'FakeMetric')])
+
+    def test_missing_method(self):
+        regexp = 'Missing configuration options for label: method'
+        with self.assertRaisesRegexp(Exception, regexp):
+            method = config.Method(None, 'label', [
+                    ('module', 'FakeClass'),
+                    ('metric', 'FakeMetric')])
+
+    def test_missing_metric(self):
+        regexp = 'Missing configuration options for label: metric'
+        with self.assertRaisesRegexp(Exception, regexp):
+            method = config.Method(None, 'label', [
+                    ('module', 'FakeClass'),
+                    ('method', 'instance_method')])
+
+    def test_init(self):
+        method = config.Method('config', 'label', [
+                ('module', 'FakeClass'),
+                ('method', 'instance_method'),
+                ('metric', 'FakeMetric'),
+                ('notifier', 'notifier'),
+                ('app_path', 'FakeHelper'),
+                ('app', 'fake_helper'),
+                ('foo', 'bar')])
+
+        self.assertEqual(method.config, 'config')
+        self.assertEqual(method.label, 'label')
+        self.assertEqual(method._app_cache, None)
+        self.assertEqual(method._metric_cache, None)
+        self.assertEqual(method.additional, {'foo': 'bar'})
+        self.assertEqual(method._module, 'FakeClass')
+        self.assertEqual(method._method, 'instance_method')
+        self.assertEqual(method._metric, 'FakeMetric')
+        self.assertEqual(method._notifier, 'notifier')
+        self.assertEqual(method._app_path, 'FakeHelper')
+        self.assertEqual(method._app, 'fake_helper')
+        self.assertEqual(method._method_cls, FakeClass)
+        self.assertTrue(inspect.isfunction(method._method_wrapper))
+        self.assertEqual(method._method_orig,
+                         FakeClass.__dict__['instance_method'])
+        self.assertEqual(method._method_wrapper.tach_descriptor, method)
+        self.assertEqual(method._method_wrapper.tach_function,
+                         FakeClass.instance_method)
+
+    def test_init_class(self):
+        method = config.Method(None, 'label', [
+                ('module', 'FakeClass'),
+                ('method', 'class_method'),
+                ('metric', 'FakeMetric')])
+
+        self.assertEqual(method._method_cls, FakeClass)
+        self.assertIsInstance(method._method_wrapper, classmethod)
+        self.assertEqual(method._method_orig,
+                         FakeClass.__dict__['class_method'])
+
+    def test_init_static(self):
+        method = config.Method(None, 'label', [
+                ('module', 'FakeClass'),
+                ('method', 'static_method'),
+                ('metric', 'FakeMetric')])
+
+        self.assertEqual(method._method_cls, FakeClass)
+        self.assertIsInstance(method._method_wrapper, staticmethod)
+        self.assertEqual(method._method_orig,
+                         FakeClass.__dict__['static_method'])
+
+    def test_init_static(self):
+        method = config.Method(None, 'label', [
+                ('module', 'FakeClass'),
+                ('method', 'static_method'),
+                ('metric', 'FakeMetric')])
+
+        self.assertEqual(method._method_cls, FakeClass)
+        self.assertIsInstance(method._method_wrapper, staticmethod)
+        self.assertEqual(method._method_orig,
+                         FakeClass.__dict__['static_method'])
+
+    def test_init_function(self):
+        method = config.Method(None, 'label', [
+                ('module', 'fake_module'),
+                ('method', 'function'),
+                ('metric', 'FakeMetric')])
+
+        self.assertEqual(method._method_cls, fake_module)
+        self.assertTrue(inspect.isfunction(method._method_wrapper))
+        self.assertEqual(method._method_orig, fake_module.function)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -474,3 +474,37 @@ class TestMethod(tests.TestCase):
                     args=(1, 2, 3),
                     kwargs=dict(a=4, b=5, c=6))))
         self.assertEqual(method.notifier.sent_msgs, [])
+
+    def test_get_app(self):
+        method = config.Method(None, 'label', [
+                ('module', 'FakeClass'),
+                ('method', 'instance_method'),
+                ('metric', 'FakeMetric'),
+                ('app_path', 'FakeHelper'),
+                ('app', 'fake_helper')])
+
+        self.assertEqual(method.app, FakeHelper.fake_helper)
+
+    def test_get_no_app(self):
+        method = config.Method(None, 'label', [
+                ('module', 'FakeClass'),
+                ('method', 'instance_method'),
+                ('metric', 'FakeMetric')])
+
+        self.assertEqual(method.app, None)
+
+    def test_get_metric(self):
+        method = config.Method(None, 'label', [
+                ('module', 'FakeClass'),
+                ('method', 'instance_method'),
+                ('metric', 'FakeMetric')])
+
+        self.assertIsInstance(method.metric, FakeMetric)
+
+    def test_get_notifier(self):
+        method = config.Method(FakeConfig(), 'label', [
+                ('module', 'FakeClass'),
+                ('method', 'instance_method'),
+                ('metric', 'FakeMetric')])
+
+        self.assertIsInstance(method.notifier, FakeNotifier)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,26 @@
+import tach
+from tach import config
+
+import tests
+
+
+class FakeConfig(object):
+    def __init__(self, path):
+        self.path = path
+        self.installed = False
+
+    def install(self):
+        self.installed = True
+
+
+class TestPatch(tests.TestCase):
+    def setUp(self):
+        super(TestPatch, self).setUp()
+
+        self.stubs.Set(config, 'Config', FakeConfig)
+
+    def test_patch(self):
+        cfg = tach.patch('foobar')
+
+        self.assertEqual(cfg.path, 'foobar')
+        self.assertEqual(cfg.installed, True)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,75 @@
+import time
+
+from tach import metrics
+
+import tests
+
+
+class TestExecTime(tests.TestCase):
+    def test_function(self):
+        metric = metrics.ExecTime({})
+        value = metric.start()
+        time.sleep(0.5)
+        result = metric(value)
+
+        self.assertAlmostEqual(result, 0.5, delta=0.1)
+
+
+class TestIncrement(tests.TestCase):
+    def test_increment(self):
+        metric = metrics.Increment({})
+        value = metric.start()
+        result = metric(value)
+
+        self.assertEqual(result, 1)
+
+    def test_decrement(self):
+        metric = metrics.Increment({'increment': '-1'})
+        value = metric.start()
+        result = metric(value)
+
+        self.assertEqual(result, -1)
+
+    def test_arbitrary(self):
+        metric = metrics.Increment({'increment': '5000'})
+        value = metric.start()
+        result = metric(value)
+
+        self.assertEqual(result, 5000)
+
+
+class MetricTest(metrics.Metric):
+    vtype = 'test'
+
+    def start(self):
+        return 'started'
+
+    def __call__(self, value):
+        return 'result'
+
+
+class TestDebug(tests.LoggingTestCase):
+    imports = {'MetricTest': MetricTest}
+
+    def test_initialize(self):
+        metric = metrics.DebugMetric({'real_metric': 'MetricTest'})
+
+        self.assertEqual(metric.metric_name, 'MetricTest')
+        self.assertIsInstance(metric.metric, MetricTest)
+        self.assertEqual(metric.vtype, MetricTest.vtype)
+
+    def test_start(self):
+        metric = metrics.DebugMetric({'real_metric': 'MetricTest'})
+        value = metric.start()
+
+        self.assertEqual(value, 'started')
+        self.assertEqual(self.logmsg[0], "DebugMetric: Starting metric "
+                         "'MetricTest': 'started'")
+
+    def test_finish(self):
+        metric = metrics.DebugMetric({'real_metric': 'MetricTest'})
+        result = metric('testing')
+
+        self.assertEqual(result, 'result')
+        self.assertEqual(self.logmsg[0], "DebugMetric: Ending metric "
+                         "'MetricTest': 'testing'/'result'")

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -1,0 +1,212 @@
+import socket
+import time
+
+from tach import notifiers
+
+import tests
+
+
+class NotifierTest(notifiers.BaseNotifier):
+    def __init__(self, config):
+        super(NotifierTest, self).__init__(config)
+
+        self.sent_msg = None
+
+    def test(self, value, label):
+        return 'test/%r/%r' % (value, label)
+
+    def default(self, value, label):
+        return 'default/%r/%r' % (value, label)
+
+    def send(self, body):
+        self.sent_msg = body
+
+
+class TestBaseNotifier(tests.TestCase):
+    def test_format(self):
+        notifier = NotifierTest({})
+        result = notifier.format('result', 'test', 'label')
+
+        self.assertEqual(result, "test/'result'/'label'")
+
+    def test_format_default(self):
+        notifier = NotifierTest({})
+        result = notifier.format('result', 'spam', 'label')
+
+        self.assertEqual(result, "default/'result'/'label'")
+
+    def test_call(self):
+        notifier = NotifierTest({})
+        notifier('result', 'test', 'label')
+
+        self.assertEqual(notifier.sent_msg, "test/'result'/'label'")
+
+
+class TestDebugNotifier(tests.LoggingTestCase):
+    imports = {'NotifierTest': NotifierTest}
+
+    def test_initialize(self):
+        notifier = notifiers.DebugNotifier({'real_driver': 'NotifierTest'})
+
+        self.assertEqual(notifier.driver_name, 'NotifierTest')
+        self.assertIsInstance(notifier.driver, NotifierTest)
+
+    def test_call(self):
+        notifier = notifiers.DebugNotifier({'real_driver': 'NotifierTest'})
+        notifier('result', 'test', 'label')
+
+        self.assertEqual(self.logmsg[0],
+                         "DebugNotifier: Notifying 'NotifierTest' of message "
+                         "\"test/'result'/'label'\"")
+        self.assertEqual(self.logmsg[1],
+                         "DebugNotifier: Raw value of type 'test': 'result'")
+        self.assertEqual(self.logmsg[2],
+                         "DebugNotifier: Statistic label: 'label'")
+
+
+class FakeSocket(object):
+    throw = None
+
+    def __init__(self, sock_type):
+        self.open = True
+        self.sock_type = sock_type
+        self.host = None
+        self.port = None
+        self.buffer = []
+
+    def connect(self, (host, port)):
+        self.host = host
+        self.port = port
+
+    def close(self):
+        self.open = False
+
+    def sendall(self, body):
+        if self.throw:
+            raise self.throw
+        self.buffer.append(body)
+
+
+class UdpSocketNotifier(notifiers.SocketNotifier):
+    sock_type = 'udp'
+
+
+class TestSocketNotifierBase(tests.LoggingTestCase):
+    def setUp(self):
+        super(TestSocketNotifierBase, self).setUp()
+
+        self.config = dict(host='test.example.com', port='12345')
+
+
+class TestSocketNotifier(TestSocketNotifierBase):
+    def setUp(self):
+        super(TestSocketNotifier, self).setUp()
+
+        def fake_socket(_family, sock_type):
+            return FakeSocket(sock_type)
+
+        self.stubs.Set(socket, 'socket', fake_socket)
+
+    def test_init(self):
+        notifier = notifiers.SocketNotifier(self.config)
+
+        self.assertEqual(notifier.host, 'test.example.com')
+        self.assertEqual(notifier.port, 12345)
+        self.assertEqual(notifier._sock, None)
+
+    def test_init_alternate(self):
+        self.config.update(alt_host='alt.example.com', alt_port='54321')
+        notifier = notifiers.SocketNotifier(self.config,
+                                            'alt_host', 'alt_port')
+
+        self.assertEqual(notifier.host, 'alt.example.com')
+        self.assertEqual(notifier.port, 54321)
+        self.assertEqual(notifier._sock, None)
+
+    def test_tcp_sock(self):
+        notifier = notifiers.SocketNotifier(self.config)
+        sock = notifier.sock
+
+        self.assertIsInstance(sock, FakeSocket)
+        self.assertEqual(sock.open, True)
+        self.assertEqual(sock.sock_type, socket.SOCK_STREAM)
+        self.assertEqual(sock.host, 'test.example.com')
+        self.assertEqual(sock.port, 12345)
+        self.assertEqual(sock.buffer, [])
+
+    def test_udp_sock(self):
+        notifier = UdpSocketNotifier(self.config)
+        sock = notifier.sock
+
+        self.assertIsInstance(sock, FakeSocket)
+        self.assertEqual(sock.open, True)
+        self.assertEqual(sock.sock_type, socket.SOCK_DGRAM)
+        self.assertEqual(sock.host, 'test.example.com')
+        self.assertEqual(sock.port, 12345)
+        self.assertEqual(sock.buffer, [])
+
+    def test_del_sock(self):
+        notifier = notifiers.SocketNotifier(self.config)
+        sock = notifier.sock
+
+        self.assertIsInstance(sock, FakeSocket)
+        self.assertEqual(sock, notifier._sock)
+
+        del notifier.sock
+
+        self.assertEqual(notifier._sock, None)
+
+    def test_send(self):
+        notifier = notifiers.SocketNotifier(self.config)
+        notifier.send('this is a test')
+
+        self.assertEqual(notifier._sock.buffer, ['this is a test'])
+
+    def test_send_reopen(self):
+        notifier = notifiers.SocketNotifier(self.config)
+        sock = notifier.sock
+        sock.throw = socket.error(1, 2, 3)
+        notifier.send('this is a test')
+
+        self.assertEqual(sock.open, False)
+        self.assertEqual(self.logmsg, [])
+        self.assertNotEqual(notifier._sock, sock)
+        self.assertEqual(notifier._sock.open, True)
+        self.assertEqual(notifier._sock.buffer, ['this is a test'])
+
+    def test_send_fail(self):
+        self.stubs.Set(FakeSocket, 'throw', socket.error(1, 2, 3))
+        notifier = notifiers.SocketNotifier(self.config)
+        notifier.send('this is a test')
+
+        self.assertEqual(self.logmsg, [
+                "SocketNotifier: Error writing to server "
+                "(test.example.com, 12345): [Errno 1] 2: 3"])
+        self.assertEqual(notifier._sock, None)
+
+
+class TestGraphiteNotifier(TestSocketNotifierBase):
+    def test_default(self):
+        notifier = notifiers.GraphiteNotifier(self.config)
+        cur_time = time.time()
+        result = notifier.default('value', 'label')
+
+        self.assertEqual(result[-1], '\n')
+        parts = result.split()
+        self.assertEqual(parts[0], 'label')
+        self.assertEqual(parts[1], 'value')
+        self.assertAlmostEqual(int(parts[2]), cur_time, delta=1)
+
+
+class TestStatsDNotifier(TestSocketNotifierBase):
+    def test_exec_time(self):
+        notifier = notifiers.StatsDNotifier(self.config)
+        result = notifier.exec_time(12.3456789, 'label')
+
+        self.assertEqual(result, 'label:12345.6789|ms')
+
+    def test_increment(self):
+        notifier = notifiers.StatsDNotifier(self.config)
+        result = notifier.increment(2, 'label')
+
+        self.assertEqual(result, 'label:2|c')

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -114,15 +114,6 @@ class TestSocketNotifier(TestSocketNotifierBase):
         self.assertEqual(notifier.port, 12345)
         self.assertEqual(notifier._sock, None)
 
-    def test_init_alternate(self):
-        self.config.update(alt_host='alt.example.com', alt_port='54321')
-        notifier = notifiers.SocketNotifier(self.config,
-                                            'alt_host', 'alt_port')
-
-        self.assertEqual(notifier.host, 'alt.example.com')
-        self.assertEqual(notifier.port, 54321)
-        self.assertEqual(notifier._sock, None)
-
     def test_tcp_sock(self):
         notifier = notifiers.SocketNotifier(self.config)
         sock = notifier.sock


### PR DESCRIPTION
Adds a full-up unit test suite for tach.  The only thing not currently tested in utils.import_class_or_module(), because I'd essentially have to fake out **import**() and sys.modules, and I'm not 100% certain it's worth it.
